### PR TITLE
add TMJ support

### DIFF
--- a/jimbo.lua
+++ b/jimbo.lua
@@ -70,17 +70,11 @@ local mod = SMODS.current_mod
         if self.config.blind then antiVal = self.config.blind.key end
         if self.edition then antiVal = nil end
 
-        if G.your_collection and G.your_collection[1] and G.your_collection[1].cards and self.config and antiVal and not dontDisable[antiVal] then
-            for j = 1, #G.your_collection do
-                for i = #G.your_collection[j].cards,1, -1 do
-                if G.your_collection[j].cards[i] == self then
+        if self.area and self.area.config.collection then
                     self.debuff = not self.debuff
                     mod.config["Disabled Things"][antiVal] = not mod.config["Disabled Things"][antiVal] or self.debuff
                     --print(mod.config["Disabled Things"][antiVal])
                     SMODS.save_mod_config(mod)
-                end
-                end
-            end
         end
         return ret
     end

--- a/jimbo.lua
+++ b/jimbo.lua
@@ -70,7 +70,7 @@ local mod = SMODS.current_mod
         if self.config.blind then antiVal = self.config.blind.key end
         if self.edition then antiVal = nil end
 
-        if self.area and self.area.config.collection then
+        if self.area and self.area.config.collection and antiVal and not dontDisable[antiVal] then
                     self.debuff = not self.debuff
                     mod.config["Disabled Things"][antiVal] = not mod.config["Disabled Things"][antiVal] or self.debuff
                     --print(mod.config["Disabled Things"][antiVal])


### PR DESCRIPTION
im not sure why the check was the way it was here (you definitely knew that you can check that, considering card.area.config.collection exists elsewhere in the code)

this is necessary so people using too many jokers can disable jokers in it